### PR TITLE
Add image badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS Command Line Interface
 
+[![](https://images.microbadger.com/badges/image/oildex/aws-cli.svg)](https://microbadger.com/images/oildex/aws-cli)
+
 The [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) is a unified tool to manage AWS services.
 
 This repository extends the official [alpine](https://hub.docker.com/_/alpine) image by adding the aws-cli package.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AWS Command Line Interface
 
 [![](https://images.microbadger.com/badges/image/oildex/aws-cli.svg)](https://microbadger.com/images/oildex/aws-cli)
+[![Anchore Image Overview](https://anchore.io/service/badges/image/f01bcc447f32c0ab9a736a0e33b602195605b009b336b173a8a5c9966e8f3b4e)](https://anchore.io/image/dockerhub/oildex%2Faws-cli%3Alatest)
 
 The [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) is a unified tool to manage AWS services.
 


### PR DESCRIPTION
Add images badges from MicroBadger and Anchore.io to the README file. They show the image's size and provide access to more information.