### PR TITLE
Update AWS CLI to 1.16.131

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.2-alpine3.9
 
-ENV AWSCLI_VERSION=1.15.80
+ENV AWSCLI_VERSION=1.16.131
 
 RUN pip install awscli==$AWSCLI_VERSION
 RUN apk add --no-cache --virtual .run-deps \


### PR DESCRIPTION
Update the the current release of AWS CLI (1.16.131, released March 25,
2019).

https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst